### PR TITLE
Update GoogleMaterialDesignIcons.java

### DIFF
--- a/src/main/java/jiconfont/icons/googlematerialdesign/GoogleMaterialDesignIcons.java
+++ b/src/main/java/jiconfont/icons/googlematerialdesign/GoogleMaterialDesignIcons.java
@@ -1,4 +1,4 @@
-package jiconfont.icons;
+package jiconfont.icons.googlematerialdesign;
 
 import jiconfont.IconCode;
 import jiconfont.IconFont;


### PR DESCRIPTION
changed package in order to make project usable as an automatic module in modular projects (Java 9 and beyond)

see https://github.com/jIconFont/jiconfont/issues/2